### PR TITLE
Parse classpath correctly when cache missing

### DIFF
--- a/plugin/leiningen.vim
+++ b/plugin/leiningen.vim
@@ -140,7 +140,7 @@ function! s:path() abort
       let response = conn.eval(
             \ '[(System/getProperty "path.separator") (System/getProperty "java.class.path")]',
             \ {'session': ''})
-      let path = split(eval(response.value[-1][5:-2]), response.value[-1][2])
+      let path = split(eval(response.value[5:-2]), response.value[2])
       call writefile([join(path, ',')], cache)
     endif
   endif


### PR DESCRIPTION
Opening a .clj file in my project was failing every time for me. Turned out it was this classpath parsing line.

Reproducible by doing `rm -r ~/.cache/vim/classpath`.
